### PR TITLE
Feature/datetime delta script

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -31,5 +31,6 @@ jobs:
         run: |
           python -c "import sys; print(sys.version)"
           python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
           python -m pip install -r requirements-dev.txt
           python -m pytest tests/unit -vv -rs -x

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -32,5 +31,5 @@ jobs:
         run: |
           python -c "import sys; print(sys.version)"
           python -m pip install --upgrade pip
-          python -m pip install requirements-dev.txt
+          python -m pip install -r requirements-dev.txt
           python -m pytest tests/unit -vv -rs -x

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -1,0 +1,36 @@
+name: Unit Tests
+
+on:
+  push:
+      branches: [ main, develop ]
+  pull_request:
+
+
+jobs:
+  setup-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+          # cache: 'pip'
+
+      - name: Cache Python deps
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.pythonLocation }}-pip-
+            ${{ runner.os }}-${{ env.pythonLocation }}-
+
+      - name: Unit Tests
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install --upgrade pip
+          python -m pip install requirements-dev.txt
+          python -m pytest tests/unit -vv -rs -x

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ install:
 	poetry shell
 	## Installing from poetry.lock - remove old dependencies no longer present in the lock file
 	poetry install --remove-untracked
+	poetry export -f requirements.txt --output requirements.txt
+	peodd -o requirements-dev.txt
 	pre-commit install
+
 
 ## Update dependencies in pyproject.toml
 update:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Installation
 
 To run the script
 
+Input dates must be
+
+- Gregorian date of format `(YYYY-MM-DD)`
+- years must be of [astronomical year number](https://en.wikipedia.org/wiki/Astronomical_year_numbering) format which follows AD/CE format for years after year 1 BC/BCE where 1 BC==0. eg. 2 BC==−1. eg. 4713 BC (-4712) `-4712-01-01`
+- no earlier than Mar 1st 4713 BC - `(-4712-03-01)`
+
+```zsh
+- after Mar 1st -
 
 ```zsh
 ❯ python datetime_delta.py -v DEBUG -d1 2020-02-28 -d2 2024-02-29

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Input dates must be
     ```
     ❯ python datetime_delta.py -v DEBUG -d1 4713-02-15 -f1 BC -d2 2024-02-29 -f2 AD
     ```
-- no earlier than Mar 1st 4713 BC
+- no earlier than Mar 1st 4713 BC (year 1 of the Julian Period).
 
 ```zsh
 ❯ python datetime_delta.py -v DEBUG -d1 2020-02-28 -d2 2024-02-29

--- a/README.md
+++ b/README.md
@@ -78,12 +78,11 @@ Input dates must be
 - no earlier than Mar 1st 4713 BC (year 1 of the Julian Period).
 
 ```zsh
-❯ python datetime_delta.py -v DEBUG -d1 2020-02-28 -d2 2024-02-29
+❯ python datetime_delta.py -v DEBUG -d1 4713-02-15 -f1 BC -d2 2024-02-29
 
-Calculating days between 2020-02-28 and 2024-02-29 CE/AD.
-debug: 2020 is a leap year
+Calculating days between 4713-02-15 BC and 2024-02-29 AD.
 debug: 2024 is a leap year
-1461 days
+982122 days
 ```
 
 To run tests

--- a/README.md
+++ b/README.md
@@ -48,3 +48,43 @@ For example, a command line application which takes two dates via stdin and retu
 You're welcome to show off your skills by getting a little more fancy. Especially if you can demonstrate applicable technology and design choices relevant to your role.
 
 A distributed machine learning solution running on the blockchain with virtual reality interface would be impressive; but overkill!
+
+
+
+## Solution
+
+## 🛠️ Requirements
+
+- [Python ^3.8.0](https://www.python.org/downloads/release/python-380/)
+
+
+## 🛠️ Getting Started
+
+Installation
+
+```zsh
+❯ make install
+```
+
+To run the script
+
+
+```zsh
+❯ python datetime_delta.py -v DEBUG -d1 2020-02-28 -d2 2024-02-29
+
+Calculating days between 2020-02-28 and 2024-02-29 CE/AD.
+debug: 2020 is a leap year
+debug: 2024 is a leap year
+1461 days
+```
+
+To run tests
+
+
+```zsh
+❯ make test
+
+or if you would like to customize test params
+❯ python -m pytest tests/unit -vv -x -rs
+
+```

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ To run the script
 Input dates must be
 
 - Gregorian date of format `(YYYY-MM-DD)`
-- years must be of [astronomical year number](https://en.wikipedia.org/wiki/Astronomical_year_numbering) format which follows AD/CE format for years after year 1 BC/BCE where 1 BC==0. eg. 2 BC==−1. eg. 4713 BC (-4712) `-4712-01-01`
-- no earlier than Mar 1st 4713 BC - `(-4712-03-01)`
-
-```zsh
-- after Mar 1st -
+- Date format is by default AD/CE. If you want to compare between BC/BCE dates, you can specify date format like so
+    ```
+    ❯ python datetime_delta.py -v DEBUG -d1 4713-02-15 -f1 BC -d2 2024-02-29 -f2 AD
+    ```
+- no earlier than Mar 1st 4713 BC
 
 ```zsh
 ❯ python datetime_delta.py -v DEBUG -d1 2020-02-28 -d2 2024-02-29

--- a/datetime_delta.py
+++ b/datetime_delta.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
-#####
 
 import logging
 from typing import Union, Tuple, List
@@ -23,8 +22,12 @@ logger = logging.getLogger(__name__)
 @click_log.simple_verbosity_option()
 @click.option("--date1", "-d1", help="Date of format `YYYY-MM-DD`", type=str)
 @click.option("--date2", "-d2", help="Date of format `YYYY-MM-DD`", type=str)
+def cli(date1: str, date2: str):
+    return main(date1=date1, date2=date2)
+
+
 def main(date1: str, date2: str):
-    logger.info(f"Calculating days between - {date1} and {date2} CE/AD.")
+    logger.info(f"Calculating days between {date1} and {date2} CE/AD.")
 
     if is_valid_date_format(date1) and is_valid_date_format(date2):
         y1, m1, d1 = map(int, date1.split("-"))
@@ -35,6 +38,8 @@ def main(date1: str, date2: str):
             days_diff = 0
 
         logger.info(f"{days_diff} days")
+        return days_diff
+    return None
 
 
 # ==================================================
@@ -50,20 +55,26 @@ def gregorian_to_jdn(year: int, month: int, day: int) -> int:
     This makes it very easy to compare relative times of events and do arithmetic between days.
     Ref: https://orbital-mechanics.space/reference/julian-date.html
     """
-    A = (month - 14) // 12
-    B = 1461 * (year + 4800 + A)
-    C = 367 * (month - 2 - (12 * A))
-    E = (year + 4900 + A) // 100
+    # A = (month-14)//12
+    # B = 1461*(year+4800+A)
+    # C = 367*(month-2-(12*A))
+    # E = (year+4900+A)//100
+    # jdn = B//4 + C//12 - (3*E)//4 + day - 32075
 
-    jdn = B // 4 + C // 12 - (3 * E) // 4 + day - 32075
+    A = year // 100
+    B = A // 4
+    C = 2 - A + B
+    E = 365.25 * (year + 4716)
+    F = 30.6001 * (month + 1)
+    jdn = int(C + day + E + F - 1524.5)
+
     return jdn
 
 
 def is_valid_date_format(date_str: str):
     """Validate date is of valid format YYYY-MM-DD"""
-    ## Basic regex check
-    date_regex = "^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
-    if bool(re.search(date_regex, date_str)):
+
+    if is_valid_date_regex(date_str):
         if is_valid_date(date_str):
             return date_str
         else:
@@ -71,7 +82,9 @@ def is_valid_date_format(date_str: str):
             logger.error(f"{err}")
             raise ValueError(f"{err}")
     else:
-        err = f"{date_str} is an invalid date format. Please enter in format YYYY-MM-DD"
+        err = (
+            f"{date_str} is an invalid date format. Please enter in format YYYY-MM-DD."
+        )
         logger.error(f"{err}")
         raise ValueError(f"{err}")
 
@@ -79,12 +92,27 @@ def is_valid_date_format(date_str: str):
 def is_valid_date(date_str: str):
     """Check for date interval and leap years"""
     y, m, d = map(int, date_str.split("-"))
-    days_in_month = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    days_in_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     if (y % 4 == 0) and (y % 400 == 0 or y % 100 != 0):
         logger.debug(f"{y} is a leap year")
-        days_in_month[1] = 29
-    return 0 <= y and 0 <= m - 1 <= 11 and 0 <= d <= days_in_month[m - 1]
+        days_in_month[2] = 29
+
+    if not (1 <= m <= 12):
+        logger.error(f"{m} is not in the correct range of 1-12.")
+        return False
+    if not (1 <= d <= days_in_month[m]):
+        logger.error(
+            f"{d} is not in the correct range of 1-{days_in_month[m]} for month {m} in year {y}."
+        )
+        return False
+
+    return True
+
+
+def is_valid_date_regex(date_str: str):
+    date_regex = r"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
+    return bool(re.search(date_regex, date_str))
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/datetime_delta.py
+++ b/datetime_delta.py
@@ -30,19 +30,21 @@ def main(date1: str, date2: str):
     logger.info(f"Calculating days between {date1} and {date2} CE/AD.")
 
     if is_valid_date_format(date1) and is_valid_date_format(date2):
-        y1, m1, d1 = map(int, date1.split("-"))
-        y2, m2, d2 = map(int, date2.split("-"))
+        y1, m1, d1 = map(int, split_date(date1))
+        y2, m2, d2 = map(int, split_date(date2))
 
-        if is_gregorian_date(y1, m1, d1):
+        if is_within_date_limit(y1, m1, d1):
+            print(gregorian_to_jdn(y1, m1, d1))
+            print(gregorian_to_jdn(y2, m2, d2))
             days_diff = (
                 abs(gregorian_to_jdn(y1, m1, d1) - gregorian_to_jdn(y2, m2, d2)) - 1
             )
             if date1 == date2:
                 days_diff = 0
 
-            logger.info(f"{days_diff} days")
+            logging.info(f"{days_diff} days")
 
-            ## Short test ##
+            # ## Short test ##
             # from datetime import datetime
 
             # date1_dt = datetime(y1, m1, d1)
@@ -82,7 +84,7 @@ def is_valid_date_format(date_str: str):
 
 def is_valid_date(date_str: str):
     """Check for date interval and leap years"""
-    y, m, d = map(int, date_str.split("-"))
+    y, m, d = map(int, split_date(date_str))
     days_in_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     if is_leap_year(y):
         logger.debug(f"{y} is a leap year")
@@ -108,34 +110,61 @@ def is_valid_date_regex(date_str: str):
     return bool(re.search(date_regex, date_str))
 
 
-def is_gregorian_date(year: int, month: int, day: int):
-    """Gregorian calendar only starts from October 15, 1582 AD."""
-    gregorian_start = gregorian_to_jdn(1582, 10, 15)
-    if gregorian_to_jdn(year, month, day) < gregorian_start:
-        logger.error(
-            f"{year}-{month}-{day} is before start of Gregorian calendar 1582-10-15"
+def split_date(date_str: str, delimiter: str = "-"):
+    """To handle negative dates in astronomical year format"""
+    date_list = date_str.split(delimiter)
+    if date_list[0] == "":
+        date_list[1] = f"-{date_list[1]}"
+        date_list = date_list[1:]
+        assert len(date_list) == 3
+    return date_list
+
+
+def is_within_date_limit(year: int, month: int, day: int):
+    """Gregorian to JDN formula date limit is after Mar 1st -4712 AD (-4712-03-01)"""
+    ## If date > Mar 1st -4712 Gregorian, Julian day num 98
+    date_limit_str = "-4712-03-01"
+    y, m, d = map(int, split_date(date_limit_str))
+
+    date_limit = gregorian_to_jdn(y, m, d)
+    if gregorian_to_jdn(year, month, day) < date_limit:
+        err = (
+            f"Gregorian date {year}-{month}-{day} is before formula limit {date_limit}"
         )
-        raise ValueError(
-            f"{year}-{month}-{day} is before Gregorian calendar 1582-10-15"
-        )
+        logger.error(err)
+        raise ValueError(err)
     return True
 
 
 def gregorian_to_jdn(year: int, month: int, day: int) -> int:
-    """Converting date to Julian day number
+    """Converting Gregorian date to Julian day number
     - January 1, 4713 BC in the proleptic Julian calendar at 12:00 PM (noon) in UTC
     - November 24, 4714 BC in the proleptic Gregorian calendar at 00:00 in UTC
     Julian days are counted as integers continuously until the present time.
-    This makes it very easy to compare relative times of events and do arithmetic between days.
-    Ref: https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
-    """
+    To compute calendar date -> jdn:
+    1. Find # days in whole years of the current Julian period
+    2. Find # days in completed months
+    3. Add numbers together, and add day of month
 
-    A = year // 100
-    B = A // 4
-    C = 2 - A + B
-    E = 365.25 * (year + 4716)
-    F = 30.6001 * (month + 1)
-    jdn = int(C + day + E + F - 1524.5)
+    Ref: https://articles.adsabs.harvard.edu//full/1984QJRAS..25...53H/0000053.000.html
+        Title: Simple Formulae for Julian Day Numbers and Calendar Dates
+        Authors: Hatcher, D. A.
+        Journal: Quarterly Journal of the Royal Astronomical Society, Vol. 25, NO.1, P. 53, 1984
+    """
+    A = year
+    M = month
+    D = day
+    A_ = A - (12 - M) // 10
+    M_ = (M - 3) % 12
+
+    y = int(365.25 * (A_ + 4712))
+    d = int(30.6 * M_ + 0.5)
+    N = y + d + D + 59
+
+    ## If date > Mar 1st -4712 Julian, jdn 60,
+    ## If date > Mar 1st -4712 Gregorian, jdn 98
+    g = int((int(A_ / 100) + 49) * 0.75) - 38
+    jdn = N - g
 
     return jdn
 

--- a/datetime_delta.py
+++ b/datetime_delta.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+#####
+
+import logging
+from typing import Union, Tuple, List
+
+import click
+import click_log
+from pathlib import Path
+import json
+import re
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+click_log.basic_config()
+logger = logging.getLogger(__name__)
+
+# ==================================================
+# =============== MAIN =============================
+# ==================================================
+@click.command()
+@click_log.simple_verbosity_option()
+@click.option("--date1", "-d1", help="Date of format `YYYY-MM-DD`", type=str)
+@click.option("--date2", "-d2", help="Date of format `YYYY-MM-DD`", type=str)
+def main(date1: str, date2: str):
+    logger.info(f"Calculating days between - {date1} and {date2} CE/AD.")
+
+    if is_valid_date_format(date1) and is_valid_date_format(date2):
+        y1, m1, d1 = map(int, date1.split("-"))
+        y2, m2, d2 = map(int, date2.split("-"))
+
+        days_diff = abs(gregorian_to_jdn(y1, m1, d1) - gregorian_to_jdn(y2, m2, d2)) - 1
+        if date1 == date2:
+            days_diff = 0
+
+        logger.info(f"{days_diff} days")
+
+
+# ==================================================
+# ============= Helper functions ===================
+# ==================================================
+
+
+def gregorian_to_jdn(year: int, month: int, day: int) -> int:
+    """Converting date to Julian day number
+    - January 1, 4713 BC in the proleptic Julian calendar at 12:00 PM (noon) in UTC
+    - November 24, 4714 BC in the proleptic Gregorian calendar at 00:00 in UTC
+    Julian days are counted as integers continuously until the present time.
+    This makes it very easy to compare relative times of events and do arithmetic between days.
+    Ref: https://orbital-mechanics.space/reference/julian-date.html
+    """
+    A = (month - 14) // 12
+    B = 1461 * (year + 4800 + A)
+    C = 367 * (month - 2 - (12 * A))
+    E = (year + 4900 + A) // 100
+
+    jdn = B // 4 + C // 12 - (3 * E) // 4 + day - 32075
+    return jdn
+
+
+def is_valid_date_format(date_str: str):
+    """Validate date is of valid format YYYY-MM-DD"""
+    ## Basic regex check
+    date_regex = "^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
+    if bool(re.search(date_regex, date_str)):
+        if is_valid_date(date_str):
+            return date_str
+        else:
+            err = f"{date_str} is an invalid date."
+            logger.error(f"{err}")
+            raise ValueError(f"{err}")
+    else:
+        err = f"{date_str} is an invalid date format. Please enter in format YYYY-MM-DD"
+        logger.error(f"{err}")
+        raise ValueError(f"{err}")
+
+
+def is_valid_date(date_str: str):
+    """Check for date interval and leap years"""
+    y, m, d = map(int, date_str.split("-"))
+    days_in_month = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    if (y % 4 == 0) and (y % 400 == 0 or y % 100 != 0):
+        logger.debug(f"{y} is a leap year")
+        days_in_month[1] = 29
+    return 0 <= y and 0 <= m - 1 <= 11 and 0 <= d <= days_in_month[m - 1]
+
+
+if __name__ == "__main__":
+    main()

--- a/datetime_delta.py
+++ b/datetime_delta.py
@@ -33,12 +33,28 @@ def main(date1: str, date2: str):
         y1, m1, d1 = map(int, date1.split("-"))
         y2, m2, d2 = map(int, date2.split("-"))
 
-        days_diff = abs(gregorian_to_jdn(y1, m1, d1) - gregorian_to_jdn(y2, m2, d2)) - 1
-        if date1 == date2:
-            days_diff = 0
+        if is_gregorian_date(y1, m1, d1):
+            days_diff = (
+                abs(gregorian_to_jdn(y1, m1, d1) - gregorian_to_jdn(y2, m2, d2)) - 1
+            )
+            if date1 == date2:
+                days_diff = 0
 
-        logger.info(f"{days_diff} days")
-        return days_diff
+            logger.info(f"{days_diff} days")
+
+            ## Short test ##
+            # from datetime import datetime
+
+            # date1_dt = datetime(y1, m1, d1)
+            # date2_dt = datetime(y2, m2, d2)
+            # days_diff_dt = abs((date1_dt - date2_dt).days)-1
+            # if date1_dt == date2_dt:
+            #     days_diff_dt = 0
+
+            # logging.info(days_diff_dt)
+            # assert days_diff == days_diff_dt
+
+            return days_diff
     return None
 
 
@@ -47,27 +63,8 @@ def main(date1: str, date2: str):
 # ==================================================
 
 
-def gregorian_to_jdn(year: int, month: int, day: int) -> int:
-    """Converting date to Julian day number
-    - January 1, 4713 BC in the proleptic Julian calendar at 12:00 PM (noon) in UTC
-    - November 24, 4714 BC in the proleptic Gregorian calendar at 00:00 in UTC
-    Julian days are counted as integers continuously until the present time.
-    This makes it very easy to compare relative times of events and do arithmetic between days.
-    Ref: https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
-    """
-    A = year // 100
-    B = A // 4
-    C = 2 - A + B
-    E = 365.25 * (year + 4716)
-    F = 30.6001 * (month + 1)
-    jdn = int(C + day + E + F - 1524.5)
-
-    return jdn
-
-
 def is_valid_date_format(date_str: str):
     """Validate date is of valid format YYYY-MM-DD"""
-
     if is_valid_date_regex(date_str):
         if is_valid_date(date_str):
             return date_str
@@ -87,7 +84,7 @@ def is_valid_date(date_str: str):
     """Check for date interval and leap years"""
     y, m, d = map(int, date_str.split("-"))
     days_in_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    if (y % 4 == 0) and (y % 400 == 0 or y % 100 != 0):
+    if is_leap_year(y):
         logger.debug(f"{y} is a leap year")
         days_in_month[2] = 29
 
@@ -99,13 +96,48 @@ def is_valid_date(date_str: str):
             f"{d} is not in the correct range of 1-{days_in_month[m]} for month {m} in year {y}."
         )
         return False
-
     return True
+
+
+def is_leap_year(year: int):
+    return (year % 4 == 0) and (year % 100 != 0 or year % 400 == 0)
 
 
 def is_valid_date_regex(date_str: str):
     date_regex = r"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     return bool(re.search(date_regex, date_str))
+
+
+def is_gregorian_date(year: int, month: int, day: int):
+    """Gregorian calendar only starts from October 15, 1582 AD."""
+    gregorian_start = gregorian_to_jdn(1582, 10, 15)
+    if gregorian_to_jdn(year, month, day) < gregorian_start:
+        logger.error(
+            f"{year}-{month}-{day} is before start of Gregorian calendar 1582-10-15"
+        )
+        raise ValueError(
+            f"{year}-{month}-{day} is before Gregorian calendar 1582-10-15"
+        )
+    return True
+
+
+def gregorian_to_jdn(year: int, month: int, day: int) -> int:
+    """Converting date to Julian day number
+    - January 1, 4713 BC in the proleptic Julian calendar at 12:00 PM (noon) in UTC
+    - November 24, 4714 BC in the proleptic Gregorian calendar at 00:00 in UTC
+    Julian days are counted as integers continuously until the present time.
+    This makes it very easy to compare relative times of events and do arithmetic between days.
+    Ref: https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
+    """
+
+    A = year // 100
+    B = A // 4
+    C = 2 - A + B
+    E = 365.25 * (year + 4716)
+    F = 30.6001 * (month + 1)
+    jdn = int(C + day + E + F - 1524.5)
+
+    return jdn
 
 
 if __name__ == "__main__":

--- a/datetime_delta.py
+++ b/datetime_delta.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
     "--format1",
     "-f1",
     help="BC/BCE or AD/CE",
-    default="CE",
+    default="AD",
     type=click.Choice(["AD", "BC", "CE", "BCE"]),
     show_default=True,
 )
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
     "--format2",
     "-f2",
     help="BC/BCE or AD/CE",
-    default="CE",
+    default="AD",
     type=click.Choice(["AD", "BC", "CE", "BCE"]),
     show_default=True,
 )

--- a/datetime_delta.py
+++ b/datetime_delta.py
@@ -53,14 +53,8 @@ def gregorian_to_jdn(year: int, month: int, day: int) -> int:
     - November 24, 4714 BC in the proleptic Gregorian calendar at 00:00 in UTC
     Julian days are counted as integers continuously until the present time.
     This makes it very easy to compare relative times of events and do arithmetic between days.
-    Ref: https://orbital-mechanics.space/reference/julian-date.html
+    Ref: https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
     """
-    # A = (month-14)//12
-    # B = 1461*(year+4800+A)
-    # C = 367*(month-2-(12*A))
-    # E = (year+4900+A)//100
-    # jdn = B//4 + C//12 - (3*E)//4 + day - 32075
-
     A = year // 100
     B = A // 4
     C = 2 - A + B

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+peodd>=0.3.0
+autopep8>=1.5.7
+pytest>=7.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+click-log==0.3.2 \
+    --hash=sha256:16fd1ca3fc6b16c98cea63acf1ab474ea8e676849dc669d86afafb0ed7003124 \
+    --hash=sha256:eee14dc37cdf3072158570f00406572f9e03e414accdccfccd4c538df9ae322c
+click==7.1.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
+    --hash=sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc \
+    --hash=sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a

--- a/tests/unit/test_datetime_delta.py
+++ b/tests/unit/test_datetime_delta.py
@@ -35,7 +35,7 @@ from datetime_delta import (
 )
 def test_main_success(date1, date2, expected_days):
 
-    assert main(date1=date1, date2=date2) == expected_days
+    assert main(date1=date1, date2=date2, format1="CE", format2="CE") == expected_days
 
 
 @pytest.mark.parametrize(
@@ -58,7 +58,7 @@ def test_main_success(date1, date2, expected_days):
 def test_main_fail(date1, date2, expected):
     with pytest.raises(expected) as e_info:
         print(e_info)
-        main(date1=date1, date2=date2)
+        main(date1=date1, date2=date2, format1="CE", format2="CE")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_datetime_delta.py
+++ b/tests/unit/test_datetime_delta.py
@@ -35,7 +35,7 @@ from datetime_delta import (
 )
 def test_main_success(date1, date2, expected_days):
 
-    assert main(date1=date1, date2=date2, format1="CE", format2="CE") == expected_days
+    assert main(date1=date1, date2=date2, format1="AD", format2="AD") == expected_days
 
 
 @pytest.mark.parametrize(
@@ -58,7 +58,7 @@ def test_main_success(date1, date2, expected_days):
 def test_main_fail(date1, date2, expected):
     with pytest.raises(expected) as e_info:
         print(e_info)
-        main(date1=date1, date2=date2, format1="CE", format2="CE")
+        main(date1=date1, date2=date2, format1="AD", format2="AD")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_datetime_delta.py
+++ b/tests/unit/test_datetime_delta.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+
+import pytest
+
+from click.testing import CliRunner
+
+runner = CliRunner()
+
+from datetime_delta import main
+
+
+@pytest.mark.parametrize(
+    ["date1", "date2", "expected_days"],
+    [
+        ("2012-01-10", "2012-01-11", 0),
+        ("2012-01-01", "2012-01-10", 8),
+        ("1801-06-13", "1801-11-11", 150),
+        ("2021-12-01", "2017-12-14", 1447),
+    ],
+)
+def test_main(date1, date2, expected_days):
+
+    assert main(date1=date1, date2=date2) == expected_days

--- a/tests/unit/test_datetime_delta.py
+++ b/tests/unit/test_datetime_delta.py
@@ -11,7 +11,7 @@ from datetime_delta import (
     is_valid_date,
     is_leap_year,
     is_valid_date_regex,
-    is_gregorian_date,
+    is_within_date_limit,
     gregorian_to_jdn,
 )
 
@@ -151,31 +151,31 @@ def test_is_valid_date_regex(date_str, expected):
 @pytest.mark.parametrize(
     ["year", "month", "day", "expected"],
     [(2000, 1, 1, True)],
-    ids=["valid_gregorian_date 2000-01-01"],
+    ids=["valid_date_limit 2000-01-01"],
 )
-def test_is_gregorian_date_success(year, month, day, expected):
-    assert is_gregorian_date(year, month, day) == expected
+def test_is_within_date_limit_success(year, month, day, expected):
+    assert is_within_date_limit(year, month, day) == expected
 
 
 @pytest.mark.parametrize(
     ["year", "month", "day", "expected"],
     [
-        (1500, 1, 1, ValueError),
-        (1582, 10, 14, ValueError),
+        (-4713, 1, 1, ValueError),
+        (-4720, 10, 14, ValueError),
     ],
-    ids=["invalid_gregorian_date 1500-01-01", "invalid_gregorian_date 1582-10-14"],
+    ids=["invalid_date_limit 1500-01-01", "invalid_date_limit 1582-10-14"],
 )
-def test_is_gregorian_date_fail(year, month, day, expected):
+def test_is_within_date_limit_fail(year, month, day, expected):
     with pytest.raises(expected) as e_info:
         print(e_info)
-        is_gregorian_date(year, month, day)
+        is_within_date_limit(year, month, day)
 
 
 @pytest.mark.parametrize(
     ["year", "month", "day", "expected"],
     [
-        (2020, 2, 28, 2458906),
-        (2024, 2, 29, 2460368),
+        (2020, 2, 28, 2458908),
+        (2024, 2, 29, 2460370),
     ],
     ids=["valid_gregorian_to_jdn 2020-02-28", "valid_gregorian_to_jdn 2024-02-29"],
 )

--- a/tests/unit/test_datetime_delta.py
+++ b/tests/unit/test_datetime_delta.py
@@ -4,22 +4,180 @@
 
 import pytest
 
-from click.testing import CliRunner
 
-runner = CliRunner()
-
-from datetime_delta import main
+from datetime_delta import (
+    main,
+    is_valid_date_format,
+    is_valid_date,
+    is_leap_year,
+    is_valid_date_regex,
+    is_gregorian_date,
+    gregorian_to_jdn,
+)
 
 
 @pytest.mark.parametrize(
     ["date1", "date2", "expected_days"],
     [
-        ("2012-01-10", "2012-01-11", 0),
+        ("2012-01-10", "2012-01-10", 0),  ## Same date should return 0
+        ("2012-01-10", "2012-01-11", 0),  ## One day difference should return 0
         ("2012-01-01", "2012-01-10", 8),
+        ("2020-01-01", "2020-02-29", 58),  ## Leap year
         ("1801-06-13", "1801-11-11", 150),
-        ("2021-12-01", "2017-12-14", 1447),
+    ],
+    ids=[
+        "same_date",
+        "1_day_diff",
+        "10_day_diff",
+        "leap_year_date",
+        "1801_date",
     ],
 )
-def test_main(date1, date2, expected_days):
+def test_main_success(date1, date2, expected_days):
 
     assert main(date1=date1, date2=date2) == expected_days
+
+
+@pytest.mark.parametrize(
+    ["date1", "date2", "expected"],
+    [
+        ("2012-1-01", "2012-01-05", ValueError),
+        ("2012-01-01", "2012-01-5", ValueError),
+        ("2020-01-01", "2019-02-29", ValueError),
+        ("2020-01-01", "2019-02-30", ValueError),
+        ("1500-01-01", "2019-02-30", ValueError),
+    ],
+    ids=[
+        "invalid_date_format YYYY-M-DD",
+        "invalid_date_format YYYY-MM-D",
+        "non_leap_year_29",
+        "feb_30_date",
+        "pre_gregorian_1582-10-15_date",
+    ],
+)
+def test_main_fail(date1, date2, expected):
+    with pytest.raises(expected) as e_info:
+        print(e_info)
+        main(date1=date1, date2=date2)
+
+
+@pytest.mark.parametrize(
+    ["date_str", "expected"],
+    [
+        ("2000-01-01", "2000-01-01"),
+        ("1585-01-01", "1585-01-01"),
+    ],
+    ids=["valid_date_format 2000-01-01", "valid_date_format 1585-01-01"],
+)
+def test_is_valid_date_format_success(date_str, expected):
+    assert is_valid_date_format(date_str) == expected
+
+
+@pytest.mark.parametrize(
+    ["date_str", "expected"],
+    [
+        ("2000-02-30", ValueError),
+        ("20000-02-30", ValueError),
+    ],
+    ids=["invalid_date_format 2000-02-30", "invalid_date_format 20000-02-30"],
+)
+def test_is_valid_date_format_fail(date_str, expected):
+    with pytest.raises(expected) as e_info:
+        print(e_info)
+        is_valid_date_format(date_str)
+
+
+@pytest.mark.parametrize(
+    ["date_str", "expected"],
+    [
+        ("2000-01-01", True),
+        ("1585-01-01", True),
+        ("1585-13-01", False),
+        ("2017-02-29", False),
+        ("2017-04-31", False),
+    ],
+    ids=[
+        "valid_date 2000-01-01",
+        "valid_date 1585-01-01",
+        "invalid_date 1585-13-01",
+        "invalid_date 2017-02-29",
+        "invalid_date 2017-04-31",
+    ],
+)
+def test_is_valid_date(date_str, expected):
+    assert is_valid_date(date_str) == expected
+
+
+@pytest.mark.parametrize(
+    ["year", "expected"],
+    [
+        (2024, True),
+        (2000, True),
+        (2200, False),
+        (1900, False),
+        (2019, False),
+    ],
+    ids=[
+        "valid_leap_year 2024",
+        "valid_leap_year 2000",
+        "invalid_leap_year 2200",
+        "invalid_leap_year 1900",
+        "invalid_leap_year 2019",
+    ],
+)
+def test_is_leap_year(year, expected):
+    assert is_leap_year(year) == expected
+
+
+@pytest.mark.parametrize(
+    ["date_str", "expected"],
+    [
+        ("2000-01-01", True),
+        ("20000-01-01", False),
+        ("1985-06-100", False),
+        ("1985-6-10", False),
+    ],
+    ids=[
+        "valid_date_regex 2000-01-01",
+        "invalid_date_regex 20000-1-01",
+        "invalid_date_regex 1985-06-100",
+        "invalid_date_regex 1985-6-10",
+    ],
+)
+def test_is_valid_date_regex(date_str, expected):
+    assert is_valid_date_regex(date_str) == expected
+
+
+@pytest.mark.parametrize(
+    ["year", "month", "day", "expected"],
+    [(2000, 1, 1, True)],
+    ids=["valid_gregorian_date 2000-01-01"],
+)
+def test_is_gregorian_date_success(year, month, day, expected):
+    assert is_gregorian_date(year, month, day) == expected
+
+
+@pytest.mark.parametrize(
+    ["year", "month", "day", "expected"],
+    [
+        (1500, 1, 1, ValueError),
+        (1582, 10, 14, ValueError),
+    ],
+    ids=["invalid_gregorian_date 1500-01-01", "invalid_gregorian_date 1582-10-14"],
+)
+def test_is_gregorian_date_fail(year, month, day, expected):
+    with pytest.raises(expected) as e_info:
+        print(e_info)
+        is_gregorian_date(year, month, day)
+
+
+@pytest.mark.parametrize(
+    ["year", "month", "day", "expected"],
+    [
+        (2020, 2, 28, 2458906),
+        (2024, 2, 29, 2460368),
+    ],
+    ids=["valid_gregorian_to_jdn 2020-02-28", "valid_gregorian_to_jdn 2024-02-29"],
+)
+def test_gregorian_to_jdn(year, month, day, expected):
+    assert gregorian_to_jdn(year, month, day) == expected


### PR DESCRIPTION
This PR prepares a simple Click CLI application `datetime_delta.py` to parse two dates of the format `YYYY-MM-DD` and returns the difference in days between them. 

The dates are converted from Gregorian to a Julian day number and then the subtracted difference returns the number of days. 

Current Gregorian -> Julian day number formula only supports input dates back to Mar 1st 4713 BC (year 1 of the Julian Period).

Input dates
- Gregorian date of format `(YYYY-MM-DD)`
- Date format is by default AD/CE. If you want to compare between BC/BCE dates, you can specify date format like so
    ```
    ❯ python datetime_delta.py -v DEBUG -d1 4713-02-15 -f1 BC -d2 2024-02-29 -f2 AD
    ```
- no earlier than Mar 1st 4713 BC (year 1 of the Julian Period).

Ref: https://articles.adsabs.harvard.edu//full/1984QJRAS..25...53H/0000053.000.html
    Title: Simple Formulae for Julian Day Numbers and Calendar Dates
    Authors: Hatcher, D. A.
    Journal: Quarterly Journal of the Royal Astronomical Society, Vol. 25, NO.1, P. 53, 1984

## 🛠️ Requirements

- [Python ^3.8.0](https://www.python.org/downloads/release/python-380/)


## 🛠️ Getting Started

Installation

```zsh
❯ make install
```

To run the script

```zsh
❯ python datetime_delta.py -v DEBUG -d1 2020-02-28 -d2 2024-02-29

Calculating days between 2020-02-28 and 2024-02-29 CE/AD.
debug: 2020 is a leap year
debug: 2024 is a leap year
1461 days
```

To run tests


```zsh
❯ make test

or if you would like to customize test params
❯ python -m pytest tests/unit -vv -x -rs

```
