### PR TITLE
fix: Changing formula to increase date limit to  Mar 1st -4712 AD

### DIFF
--- a/datetime_delta.py
+++ b/datetime_delta.py
@@ -30,19 +30,21 @@ def main(date1: str, date2: str):
     logger.info(f"Calculating days between {date1} and {date2} CE/AD.")
 
     if is_valid_date_format(date1) and is_valid_date_format(date2):
-        y1, m1, d1 = map(int, date1.split("-"))
-        y2, m2, d2 = map(int, date2.split("-"))
+        y1, m1, d1 = map(int, split_date(date1))
+        y2, m2, d2 = map(int, split_date(date2))
 
-        if is_gregorian_date(y1, m1, d1):
+        if is_within_date_limit(y1, m1, d1):
+            print(gregorian_to_jdn(y1, m1, d1))
+            print(gregorian_to_jdn(y2, m2, d2))
             days_diff = (
                 abs(gregorian_to_jdn(y1, m1, d1) - gregorian_to_jdn(y2, m2, d2)) - 1
             )
             if date1 == date2:
                 days_diff = 0
 
-            logger.info(f"{days_diff} days")
+            logging.info(f"{days_diff} days")
 
-            ## Short test ##
+            # ## Short test ##
             # from datetime import datetime
 
             # date1_dt = datetime(y1, m1, d1)
@@ -82,7 +84,7 @@ def is_valid_date_format(date_str: str):
 
 def is_valid_date(date_str: str):
     """Check for date interval and leap years"""
-    y, m, d = map(int, date_str.split("-"))
+    y, m, d = map(int, split_date(date_str))
     days_in_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     if is_leap_year(y):
         logger.debug(f"{y} is a leap year")
@@ -108,34 +110,61 @@ def is_valid_date_regex(date_str: str):
     return bool(re.search(date_regex, date_str))
 
 
-def is_gregorian_date(year: int, month: int, day: int):
-    """Gregorian calendar only starts from October 15, 1582 AD."""
-    gregorian_start = gregorian_to_jdn(1582, 10, 15)
-    if gregorian_to_jdn(year, month, day) < gregorian_start:
-        logger.error(
-            f"{year}-{month}-{day} is before start of Gregorian calendar 1582-10-15"
+def split_date(date_str: str, delimiter: str = "-"):
+    """To handle negative dates in astronomical year format"""
+    date_list = date_str.split(delimiter)
+    if date_list[0] == "":
+        date_list[1] = f"-{date_list[1]}"
+        date_list = date_list[1:]
+        assert len(date_list) == 3
+    return date_list
+
+
+def is_within_date_limit(year: int, month: int, day: int):
+    """Gregorian to JDN formula date limit is after Mar 1st -4712 AD (-4712-03-01)"""
+    ## If date > Mar 1st -4712 Gregorian, Julian day num 98
+    date_limit_str = "-4712-03-01"
+    y, m, d = map(int, split_date(date_limit_str))
+
+    date_limit = gregorian_to_jdn(y, m, d)
+    if gregorian_to_jdn(year, month, day) < date_limit:
+        err = (
+            f"Gregorian date {year}-{month}-{day} is before formula limit {date_limit}"
         )
-        raise ValueError(
-            f"{year}-{month}-{day} is before Gregorian calendar 1582-10-15"
-        )
+        logger.error(err)
+        raise ValueError(err)
     return True
 
 
 def gregorian_to_jdn(year: int, month: int, day: int) -> int:
-    """Converting date to Julian day number
+    """Converting Gregorian date to Julian day number
     - January 1, 4713 BC in the proleptic Julian calendar at 12:00 PM (noon) in UTC
     - November 24, 4714 BC in the proleptic Gregorian calendar at 00:00 in UTC
     Julian days are counted as integers continuously until the present time.
-    This makes it very easy to compare relative times of events and do arithmetic between days.
-    Ref: https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
-    """
+    To compute calendar date -> jdn:
+    1. Find # days in whole years of the current Julian period
+    2. Find # days in completed months
+    3. Add numbers together, and add day of month
 
-    A = year // 100
-    B = A // 4
-    C = 2 - A + B
-    E = 365.25 * (year + 4716)
-    F = 30.6001 * (month + 1)
-    jdn = int(C + day + E + F - 1524.5)
+    Ref: https://articles.adsabs.harvard.edu//full/1984QJRAS..25...53H/0000053.000.html
+        Title: Simple Formulae for Julian Day Numbers and Calendar Dates
+        Authors: Hatcher, D. A.
+        Journal: Quarterly Journal of the Royal Astronomical Society, Vol. 25, NO.1, P. 53, 1984
+    """
+    A = year
+    M = month
+    D = day
+    A_ = A - (12 - M) // 10
+    M_ = (M - 3) % 12
+
+    y = int(365.25 * (A_ + 4712))
+    d = int(30.6 * M_ + 0.5)
+    N = y + d + D + 59
+
+    ## If date > Mar 1st -4712 Julian, jdn 60,
+    ## If date > Mar 1st -4712 Gregorian, jdn 98
+    g = int((int(A_ / 100) + 49) * 0.75) - 38
+    jdn = N - g
 
     return jdn
 

--- a/tests/unit/test_datetime_delta.py
+++ b/tests/unit/test_datetime_delta.py
@@ -11,7 +11,7 @@ from datetime_delta import (
     is_valid_date,
     is_leap_year,
     is_valid_date_regex,
-    is_gregorian_date,
+    is_within_date_limit,
     gregorian_to_jdn,
 )
 
@@ -151,31 +151,31 @@ def test_is_valid_date_regex(date_str, expected):
 @pytest.mark.parametrize(
     ["year", "month", "day", "expected"],
     [(2000, 1, 1, True)],
-    ids=["valid_gregorian_date 2000-01-01"],
+    ids=["valid_date_limit 2000-01-01"],
 )
-def test_is_gregorian_date_success(year, month, day, expected):
-    assert is_gregorian_date(year, month, day) == expected
+def test_is_within_date_limit_success(year, month, day, expected):
+    assert is_within_date_limit(year, month, day) == expected
 
 
 @pytest.mark.parametrize(
     ["year", "month", "day", "expected"],
     [
-        (1500, 1, 1, ValueError),
-        (1582, 10, 14, ValueError),
+        (-4713, 1, 1, ValueError),
+        (-4720, 10, 14, ValueError),
     ],
-    ids=["invalid_gregorian_date 1500-01-01", "invalid_gregorian_date 1582-10-14"],
+    ids=["invalid_date_limit 1500-01-01", "invalid_date_limit 1582-10-14"],
 )
-def test_is_gregorian_date_fail(year, month, day, expected):
+def test_is_within_date_limit_fail(year, month, day, expected):
     with pytest.raises(expected) as e_info:
         print(e_info)
-        is_gregorian_date(year, month, day)
+        is_within_date_limit(year, month, day)
 
 
 @pytest.mark.parametrize(
     ["year", "month", "day", "expected"],
     [
-        (2020, 2, 28, 2458906),
-        (2024, 2, 29, 2460368),
+        (2020, 2, 28, 2458908),
+        (2024, 2, 29, 2460370),
     ],
     ids=["valid_gregorian_to_jdn 2020-02-28", "valid_gregorian_to_jdn 2024-02-29"],
 )


### PR DESCRIPTION
Changing out formula to accommodate for input dates to Mar 1st -4712 AD or Mar 1st 4712 BC.

Dates are still expected to be Gregorian.

Tested against values returned `datetime` lib.

Formula now changed to 

```
    To compute calendar date -> jdn:
    1. Find # days in whole years of the current Julian period
    2. Find # days in completed months
    3. Add numbers together, and add day of month
```


  Ref: https://articles.adsabs.harvard.edu//full/1984QJRAS..25...53H/0000053.000.html
      Title: Simple Formulae for Julian Day Numbers and Calendar Dates
      Authors: Hatcher, D. A.
      Journal: Quarterly Journal of the Royal Astronomical Society, Vol. 25, NO.1, P. 53, 1984
